### PR TITLE
Add automatic encoding fallback for CSV and JSON file loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "matplotlib==3.10.1",
     "scipy==1.15.2",
     "openpyxl==3.1.5",
+    "python-calamine>=0.2.0",
     "pyarrow==19.0.1",
     "tqdm"
 ]


### PR DESCRIPTION
## Summary
This PR improves the robustness of file loading by implementing automatic encoding fallback for CSV and JSON files. When the primary encoding fails with a `UnicodeDecodeError`, the system now automatically attempts alternative encodings before raising an error.

## Key Changes
- **New utility function `_ler_com_fallback_encoding()`**: A generic fallback mechanism that wraps file reading operations and automatically tries alternative encodings when the primary encoding fails
- **Enhanced CSV loading**: `pd.read_csv()` now uses the fallback mechanism with `latin-1` and `cp1252` as alternatives to the primary encoding
- **Enhanced JSON loading**: `pd.read_json()` now uses the same fallback mechanism for consistency
- **Improved logging**: Added warning, info, and debug level logs to guide users through encoding issues and suggest UTF-8 as the preferred format
- **Better error messages**: When all encodings fail, users receive a detailed error message listing all attempted encodings and suggesting next steps

## Implementation Details
- The fallback encodings (`latin-1` and `cp1252`) are specifically chosen for compatibility with Excel-generated CSV files common in Brazil and Portugal
- The solution uses a lambda-based approach to defer encoding parameter passing, allowing the same fallback logic to work with different pandas read functions
- Logging is stratified by level: warnings for initial failures, info for successful fallback, and debug for intermediate attempts
- The implementation maintains backward compatibility while providing a better user experience for encoding-related issues

https://claude.ai/code/session_012MHXvbjmav166Z392mQEas